### PR TITLE
Bypass rate limit when not logged in

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/AnonymousAccessTokenInterceptor.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/AnonymousAccessTokenInterceptor.java
@@ -1,0 +1,101 @@
+package ml.docilealligator.infinityforreddit;
+
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import ml.docilealligator.infinityforreddit.apis.RedditAPI;
+import ml.docilealligator.infinityforreddit.utils.APIUtils;
+import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
+import okhttp3.Headers;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+
+public class AnonymousAccessTokenInterceptor implements Interceptor {
+    private Retrofit mRetrofit;
+    private SharedPreferences mAnonymousAccountSharedPreferences;
+
+    public AnonymousAccessTokenInterceptor(Retrofit retrofit, SharedPreferences anonymousAccountSharedPreferences) {
+        mRetrofit = retrofit;
+        mAnonymousAccountSharedPreferences = anonymousAccountSharedPreferences;
+    }
+
+    @NonNull
+    @Override
+    public Response intercept(@NonNull Chain chain) throws IOException {
+        String accessToken = mAnonymousAccountSharedPreferences.getString(SharedPreferencesUtils.ACCESS_TOKEN, "");
+        if ("".equals(accessToken)) {
+            accessToken = refreshAccessToken();
+        }
+
+        Response response = chain.proceed(newRequest(chain.request(), accessToken));
+
+        if (response.code() != 401) {
+            return response;
+        }
+
+        final String accessTokenFromDatabase = accessToken;
+        String accessTokenHeader = response.request().header(APIUtils.AUTHORIZATION_KEY);
+        if (accessTokenHeader == null) {
+            return response;
+        }
+
+        accessToken = accessTokenHeader.substring(APIUtils.AUTHORIZATION_BASE.length());
+        synchronized (this) {
+            if (accessToken.equals(accessTokenFromDatabase)) {
+                final String newAccessToken = refreshAccessToken();
+                if ("".equals(newAccessToken)) {
+                    return response;
+                } else {
+                    response.close();
+                    return chain.proceed(newRequest(response.request(), newAccessToken));
+                }
+            } else {
+                return response;
+            }
+        }
+    }
+
+    private Request newRequest(Request request, String accessToken) {
+        return request.newBuilder()
+                .headers(Headers.of(APIUtils.getOAuthHeader(accessToken)))
+                .build();
+    }
+
+    private String refreshAccessToken() {
+        RedditAPI api = mRetrofit.create(RedditAPI.class);
+
+        Map<String, String> accessTokenFields = new HashMap<>();
+        accessTokenFields.put(APIUtils.GRANT_TYPE_KEY, APIUtils.GRANT_TYPE_INSTALLED_CLIENT);
+        accessTokenFields.put(APIUtils.DEVICE_ID_KEY, mAnonymousAccountSharedPreferences.getString(SharedPreferencesUtils.DEVICE_ID, ""));
+
+        Call<String> accessTokenCall = api.getAccessToken(APIUtils.getHttpBasicAuthHeader(), accessTokenFields);
+        try {
+            retrofit2.Response<String> response = accessTokenCall.execute();
+            if (response.isSuccessful() && response.body() != null) {
+                JSONObject jsonObject = new JSONObject(response.body());
+                String newAccessToken = jsonObject.getString(APIUtils.ACCESS_TOKEN_KEY);
+
+                mAnonymousAccountSharedPreferences.edit()
+                        .putString(SharedPreferencesUtils.ACCESS_TOKEN, newAccessToken).apply();
+
+                return newAccessToken;
+            }
+            return "";
+        } catch (IOException | JSONException e) {
+            e.printStackTrace();
+        }
+
+        return "";
+    }
+}

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/AppModule.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/AppModule.java
@@ -118,6 +118,12 @@ abstract class AppModule {
     }
 
     @Provides
+    @Named("anonymous_account")
+    static SharedPreferences provideAnonymousAccountSharedPreferences(Application application) {
+        return application.getSharedPreferences(SharedPreferencesUtils.ANONYMOUS_ACCOUNT_SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
+    }
+
+    @Provides
     @Named("navigation_drawer")
     static SharedPreferences provideNavigationDrawerSharedPreferences(Application application) {
         return application.getSharedPreferences(SharedPreferencesUtils.NAVIGATION_DRAWER_SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/Infinity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/Infinity.java
@@ -35,6 +35,7 @@ import androidx.lifecycle.OnLifecycleEvent;
 import androidx.lifecycle.ProcessLifecycleOwner;
 
 import java.util.Arrays;
+import java.util.UUID;
 
 import ml.docilealligator.infinityforreddit.activities.LockScreenActivity;
 import ml.docilealligator.infinityforreddit.broadcastreceivers.NetworkWifiStatusReceiver;
@@ -65,6 +66,9 @@ public class Infinity extends Application implements LifecycleObserver {
     @Named("default")
     SharedPreferences mSharedPreferences;
     @Inject
+    @Named("anonymous_account")
+    SharedPreferences mAnonymousAccountSharedPreferences;
+    @Inject
     @Named("security")
     SharedPreferences mSecuritySharedPreferences;
 
@@ -89,6 +93,10 @@ public class Infinity extends Application implements LifecycleObserver {
             SessionHolder.INSTANCE.setCurrentSession(lastSession);
             lastSession.open();
             lastSession.startSync(true);
+        }
+
+        if (!mAnonymousAccountSharedPreferences.contains(SharedPreferencesUtils.DEVICE_ID)) {
+            mAnonymousAccountSharedPreferences.edit().putString(SharedPreferencesUtils.DEVICE_ID, UUID.randomUUID().toString().toLowerCase()).apply();
         }
 
         try {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/NetworkModule.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/NetworkModule.java
@@ -52,9 +52,24 @@ abstract class NetworkModule {
     }
 
     @Provides
+    @Named("anonymous")
+    @Singleton
+    static OkHttpClient provideAnonymousAuthOkHttpClient(@Named("base") OkHttpClient httpClient,
+                                            @Named("base") Retrofit retrofit,
+                                            @Named("anonymous_account") SharedPreferences anonymousAccountSharedPreferences) {
+        return httpClient.newBuilder()
+                .addInterceptor(new AnonymousAccessTokenInterceptor(retrofit, anonymousAccountSharedPreferences))
+                .build();
+    }
+
+    @Provides
     @Named("no_oauth")
-    static Retrofit provideRetrofit(@Named("base") Retrofit retrofit) {
-        return retrofit;
+    static Retrofit provideRetrofit(@Named("base") Retrofit retrofit,
+                                    @Named("anonymous") OkHttpClient okHttpClient) {
+        return retrofit.newBuilder()
+                .baseUrl(APIUtils.OAUTH_API_BASE_URI)
+                .client(okHttpClient)
+                .build();
     }
 
     @Provides

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/APIUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/APIUtils.java
@@ -48,6 +48,9 @@ public class APIUtils {
 
     public static final String GRANT_TYPE_KEY = "grant_type";
     public static final String GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
+    public static final String GRANT_TYPE_INSTALLED_CLIENT = "https://oauth.reddit.com/grants/installed_client";
+
+    public static final String DEVICE_ID_KEY = "device_id";
 
     public static final String DIR_KEY = "dir";
     public static final String ID_KEY = "id";

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -348,6 +348,8 @@ public class SharedPreferencesUtils {
     public static final String SESSION_EXPIRY = "session_expiry";
     public static final String REDDIT_SESSION = "reddit_session";
 
+    public static final String ANONYMOUS_ACCOUNT_SHARED_PREFERENCES_FILE = "ml.docilealligator.infinityforreddit.anonymous_account";
+    public static final String DEVICE_ID = "device_id";
 
     public static final String NAVIGATION_DRAWER_SHARED_PREFERENCES_FILE = "ml.docilealligator.infinityforreddit.navigation_drawer";
     public static final String COLLAPSE_ACCOUNT_SECTION = "collapse_account_section";


### PR DESCRIPTION
Requests coming from unauthorized users now also partially mimic the official application (we get an OAuth access token based on a random UUID / Device ID), which bypasses the rate limit of 10 requests per minute.