### PR TITLE
Quick fix for Collectible Expression rendering crash.

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/Utils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/Utils.java
@@ -88,6 +88,7 @@ public final class Utils {
     public static String inlineImages(String body, JSONObject mediaMetadata) {
         String value = body;
         JSONArray names = mediaMetadata.names();
+        if (names == null) { return "*Unable to render Collectible Expression.*\n\n"+value; }
         try{
             for(int i=0; i<names.length(); i++){
                 String id = names.getString(i);
@@ -110,7 +111,7 @@ public final class Utils {
                 value = value.replace(id, url);
             }
         }catch (JSONException e){
-
+            //e.printStackTrace();
         }
         return value;
     }


### PR DESCRIPTION
Re: #18 

Quick fix that prevents app crashes and injects a short info message for comments that contain reddit's new collectible expressions.

Results in the short info message, and the default "unable to render image" icon in the comment.

This is not a good fix and should be replaced asap, but it will prevent crashes.

